### PR TITLE
Removed erroneous description of data from datafls help page

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -2,8 +2,8 @@
 #'
 #' The economic growth data set from Fernandez, Ley and Steel, Journal of Applied Econometrics 2001
 #'
-#' @format A data frame with 53940 rows and 10 variables:
-#' A data frame with 72 observations on the following 42 variables.
+#' @format
+#' A data frame with 72 observations on the following 42 variables:
 #'  \describe{
 #'    \item{\code{y}}{numeric: Economic growth 1960-1992 as from the Penn World Tables Rev 6.0}
 #'    \item{\code{Abslat}}{numeric: Absolute latitude}


### PR DESCRIPTION
The datafls help page shows the following header message:

---
Format
A data frame with 53940 rows and 10 variables: A data frame with 72 observations on the following 42 variables.
---

I believe the first sentence was incorrectly copied from the ggplot2 diamonds dataset. 

<img width="683" height="302" alt="image" src="https://github.com/user-attachments/assets/d6730121-4bfc-4904-8fdc-77c922327a97" />
